### PR TITLE
Install x86 (32-bit) shell ext. on x64 machine

### DIFF
--- a/bootstrapper.wxs
+++ b/bootstrapper.wxs
@@ -27,7 +27,6 @@
     <Variable Name="RunQesteidutil" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
     <Variable Name="InstallX64" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="$(var.defaultX64)"/>
     <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles6432Folder]\Open-EID"/>
-    <Variable Name="InstallFolder32" Type="string" Value="[ProgramFilesFolder]\Open-EID"/>
 
     <?define REGPath = "Software\[WixBundleManufacturer]\Open-EID"?>
     <!--util:RegistrySearch Root="HKLM" Key="Software\Estonian ID Card" Value="Installed" Variable="EstEIDInstallFolder"/-->
@@ -128,13 +127,11 @@
       <MsiPackage Id="qdigidoc.en_US.X86" InstallCondition="NOT UserLanguageID = 1061 AND (NOT VersionNT64 OR InstallX64 = 0) AND QdigidocInstall = 1" ForcePerMachine="yes"
           SourceFile="$(var.qdigidoc).x86.en-US.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
         <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
-        <MsiProperty Name="APPLICATIONFOLDER32" Value="[InstallFolder32]"/>
         <MsiProperty Name="DESKTOP_SHORTCUT" Value="[IconsDesktop]"/>
       </MsiPackage>
       <MsiPackage Id="qdigidoc.et_EE.X86" InstallCondition="UserLanguageID = 1061 AND (NOT VersionNT64 OR InstallX64 = 0) AND QdigidocInstall = 1" ForcePerMachine="yes"
           SourceFile="$(var.qdigidoc).x86.et-EE.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
         <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
-        <MsiProperty Name="APPLICATIONFOLDER32" Value="[InstallFolder32]"/>
         <MsiProperty Name="DESKTOP_SHORTCUT" Value="[IconsDesktop]"/>
       </MsiPackage>
 

--- a/bootstrapper.wxs
+++ b/bootstrapper.wxs
@@ -27,6 +27,7 @@
     <Variable Name="RunQesteidutil" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
     <Variable Name="InstallX64" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="$(var.defaultX64)"/>
     <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles6432Folder]\Open-EID"/>
+    <Variable Name="InstallFolder32" Type="string" Value="[ProgramFilesFolder]\Open-EID"/>
 
     <?define REGPath = "Software\[WixBundleManufacturer]\Open-EID"?>
     <!--util:RegistrySearch Root="HKLM" Key="Software\Estonian ID Card" Value="Installed" Variable="EstEIDInstallFolder"/-->
@@ -127,15 +128,17 @@
       <MsiPackage Id="qdigidoc.en_US.X86" InstallCondition="NOT UserLanguageID = 1061 AND (NOT VersionNT64 OR InstallX64 = 0) AND QdigidocInstall = 1" ForcePerMachine="yes"
           SourceFile="$(var.qdigidoc).x86.en-US.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
         <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
+        <MsiProperty Name="APPLICATIONFOLDER32" Value="[InstallFolder32]"/>
         <MsiProperty Name="DESKTOP_SHORTCUT" Value="[IconsDesktop]"/>
       </MsiPackage>
       <MsiPackage Id="qdigidoc.et_EE.X86" InstallCondition="UserLanguageID = 1061 AND (NOT VersionNT64 OR InstallX64 = 0) AND QdigidocInstall = 1" ForcePerMachine="yes"
           SourceFile="$(var.qdigidoc).x86.et-EE.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
         <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
+        <MsiProperty Name="APPLICATIONFOLDER32" Value="[InstallFolder32]"/>
         <MsiProperty Name="DESKTOP_SHORTCUT" Value="[IconsDesktop]"/>
       </MsiPackage>
 
-      <MsiPackage Id="shellext.X86" InstallCondition="NOT VersionNT64 AND QdigidocInstall = 1" ForcePerMachine="yes"
+      <MsiPackage Id="shellext.X86" InstallCondition="QdigidocInstall = 1" ForcePerMachine="yes"
           SourceFile="$(var.shellext).x86.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
         <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
       </MsiPackage>


### PR DESCRIPTION
IB-4451: Install x86 (32-bit) shell extension also on 64-bit machine so that 32-bit
         applications have context-sensitive menu.
NB! Must be handled together with https://github.com/open-eid/qdigidoc/commit/f2e8039cbc877bb1d0f45483552cbd76a3e22ab6
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>