### PR TITLE
Install x86 shell extension after x64 installer

### DIFF
--- a/bootstrapper.wxs
+++ b/bootstrapper.wxs
@@ -135,12 +135,14 @@
         <MsiProperty Name="DESKTOP_SHORTCUT" Value="[IconsDesktop]"/>
       </MsiPackage>
 
-      <MsiPackage Id="shellext.X86" InstallCondition="QdigidocInstall = 1" ForcePerMachine="yes"
-          SourceFile="$(var.shellext).x86.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
-        <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
-      </MsiPackage>
       <MsiPackage Id="shellext.X64" InstallCondition="VersionNT64 AND QdigidocInstall = 1" ForcePerMachine="yes"
           SourceFile="$(var.shellext).x64.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
+        <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
+      </MsiPackage>
+      <!-- x86 shell extension package must be installed after the x64 since previous versions of shell extensions used same upgrade code;
+           Installation of x64 after x86 shall remove previous package, including newly installed registry entries -->
+      <MsiPackage Id="shellext.X86" InstallCondition="QdigidocInstall = 1" ForcePerMachine="yes"
+          SourceFile="$(var.shellext).x86.msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
         <MsiProperty Name="APPLICATIONFOLDER" Value="[InstallFolder]"/>
       </MsiPackage>
 


### PR DESCRIPTION
IB-4451: Install x86 shell extension after x64 installer, otherwise x64
shall remove registry entries of x86 if shell extension was installed with
old installer. Old installer used same UpgradeCode as x64 for both
versions.
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>