### PR TITLE
Add TeRa installer to the eID bootstrap installer

### DIFF
--- a/HyperlinkSidebarTheme.en.wxl
+++ b/HyperlinkSidebarTheme.en.wxl
@@ -69,6 +69,7 @@ Instructions on how to enable token plugin can be found &lt;a href="http://id.ee
   <String Id="install">Install</String>
   <String Id="qdigidoc">DigiDoc3 Client</String>
   <String Id="qesteidutil">ID-card utility</String>
+  <String Id="tera">TeRa Client</String>
   <String Id="ieplugin">Internet Explorer browser signing support</String>
   <String Id="chromeplugin">Chrome and Firefox signing support</String>
   <String Id="firefoxplugin">Firefox legacy signing and authentication support</String>

--- a/HyperlinkSidebarTheme.et.wxl
+++ b/HyperlinkSidebarTheme.et.wxl
@@ -69,6 +69,7 @@ Juhend aktiveerimiseks on leitav &lt;a href="http://id.ee/?lang=et&amp;id=36636"
   <String Id="install">Paigalda</String>
   <String Id="qdigidoc">DigiDoc3 klient</String>
   <String Id="qesteidutil">ID-kaardi haldusvahend</String>
+  <String Id="tera">TeRa klient</String>
   <String Id="ieplugin">Internet Exploreri allkirjastamise tugi</String>
   <String Id="chromeplugin">Chrome ja Firefox allkirjastamise tugi</String>
   <String Id="firefoxplugin">Firefox legacy allkirjastamise ja autentimise tugi</String>

--- a/HyperlinkSidebarTheme.xml
+++ b/HyperlinkSidebarTheme.xml
@@ -84,8 +84,9 @@
     <Checkbox Name="IESupport" X="30" Y="190" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.install) #(loc.ieplugin)</Checkbox>
     <Checkbox Name="ChromeSupport" X="30" Y="212" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.install) #(loc.chromeplugin)</Checkbox>
     <Checkbox Name="FirefoxSupport" X="30" Y="234" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.install) #(loc.firefoxplugin)</Checkbox>
-    <Static X="30" Y="253" Width="-30" Height="1" />
-    <Checkbox Name="IconsDesktop" X="30" Y="256" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.OptionsDesktop)</Checkbox>
+    <Checkbox Name="TeRaInstall" X="30" Y="256" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.install) #(loc.tera)</Checkbox>
+    <Static X="30" Y="275" Width="-30" Height="1" />
+    <Checkbox Name="IconsDesktop" X="30" Y="278" Width="-11" Height="17" TabStop="yes" FontId="3">#(loc.OptionsDesktop)</Checkbox>
     <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
     <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
     <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A WIX bootstrapper EXE with DigiDoc, ID-card utility and package with various dr
    * Digidoc3_Client*.msi
    * ID-card_utility*.msi
    * ID-Updater*.msi
+   * TeRa*.msi
    * chrome-token-signing*.msi
    * esteid-plugin-ie*.msi
    * firefox_pkcs11_loader*.msi

--- a/bootstrapper.wxs
+++ b/bootstrapper.wxs
@@ -22,6 +22,7 @@
     <Variable Name="MinidriverInstall" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
     <Variable Name="QdigidocInstall" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
     <Variable Name="QesteidutilInstall" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
+    <Variable Name="TeRaInstall" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
     <Variable Name="IconsDesktop" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
     <Variable Name="AutoUpdate" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
     <Variable Name="RunQesteidutil" Persisted="yes" bal:Overridable="yes" Type="numeric" Value="1"/>
@@ -48,6 +49,8 @@
     <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="QdigidocInstall" Variable="QdigidocInstall" Condition="QdigidocInstallExists"/>
     <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="QesteidutilInstall" Variable="QesteidutilInstallExists" Result="exists"/>
     <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="QesteidutilInstall" Variable="QesteidutilInstall" Condition="QesteidutilInstallExists"/>
+    <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="TeRaInstall" Variable="TeRaInstallExists" Result="exists"/>
+    <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="TeRaInstall" Variable="TeRaInstall" Condition="TeRaInstallExists"/>
     <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="AutoUpdate" Variable="AutoUpdateExists" Result="exists"/>
     <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="AutoUpdate" Variable="AutoUpdate" Condition="AutoUpdateExists"/>
     <util:RegistrySearch Root="HKLM" Key="$(var.REGPath)" Value="IconsDesktop" Variable="IconsDesktopExists" Result="exists"/>
@@ -176,6 +179,13 @@
         <MsiProperty Name="RUN_UTIL" Value="[RunQesteidutil]"/>
       </MsiPackage>
 
+      <MsiPackage Id="TeRa_x86" InstallCondition="NOT VersionNT64 AND TeRaInstall = 1" ForcePerMachine="yes"
+          SourceFile="TeRa_x86.$(var.teraVersion).msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
+      </MsiPackage>
+      <MsiPackage Id="TeRa_x64" InstallCondition="VersionNT64 AND TeRaInstall = 1" ForcePerMachine="yes"
+          SourceFile="TeRa_x64.$(var.teraVersion).msi" DownloadUrl="$(var.URL)" Compressed="$(var.embed)">
+      </MsiPackage>
+
       <MsiPackage Id="MetaInfo" ForcePerMachine="yes" SourceFile="metainfo.msi" Compressed="yes">
         <MsiProperty Name="IESupport" Value="[IESupport]"/>
         <MsiProperty Name="ChromeSupport" Value="[ChromeSupport]"/>
@@ -183,6 +193,7 @@
         <MsiProperty Name="MinidriverInstall" Value="[MinidriverInstall]"/>
         <MsiProperty Name="QdigidocInstall" Value="[QdigidocInstall]"/>
         <MsiProperty Name="QesteidutilInstall" Value="[QesteidutilInstall]"/>
+        <MsiProperty Name="TeRaInstall" Value="[TeRaInstall]"/>
         <MsiProperty Name="AutoUpdate" Value="[AutoUpdate]"/>
         <MsiProperty Name="IconsDesktop" Value="[IconsDesktop]"/>
       </MsiPackage>

--- a/build.ps1
+++ b/build.ps1
@@ -15,21 +15,33 @@ param(
    [string]$chrome = "chrome-token-signing",
    [string]$firefox = "firefox-token-signing",
    [string]$loader = "firefox-pkcs11-loader",
+   [string]$tera = "TeRa",
+   [string]$teraVersion = $null,
    [string]$embed = "no",
    [string]$sign = $null
 )
 
-Function GetBaseName($find, $substring) {
+Function GetFileName($find) {
     $list = Get-ChildItem "$find*"
     if($list -is [system.array]) {
         $find = $list[0].BaseName
     } else {
         $find = $list.BaseName
     }
+    return $find
+}
+
+Function GetBaseName($find, $substring) {
+    $find = GetFileName $find
     if($substring) {
         $find = $find.Substring(0, $find.Length - $substring)
     }
     return $find
+}
+
+Function GetVersion($find) {
+    $find = GetFileName $find
+    return $find.Substring($find.IndexOf('.') + 1)
 }
 
 $path = split-path -parent $MyInvocation.MyCommand.Definition
@@ -42,6 +54,7 @@ $chrome = GetBaseName $chrome 4
 $firefox = GetBaseName $firefox 4
 $loader = GetBaseName $loader 4
 $minidriver = GetBaseName $minidriver 4
+$teraVersion = GetVersion $tera
 
 Function Sign($filename) {
     signtool.exe sign /a /v /s MY /n "$sign" /fd SHA256 /du http://installer.id.ee `
@@ -50,7 +63,7 @@ Function Sign($filename) {
 Function Create($wxs, $filename, $defaultX64) {
     & $candle "$path\$wxs.wxs" -nologo -ext WixBalExtension -ext WixUtilExtension `
         "-dMSI_VERSION=$msiversion" "-dpath=$path" "-ddefaultX64=$defaultX64" "-dURL=$url" "-dembed=$embed" `
-        "-dupdater=$updater" "-dqesteidutil=$qesteid" "-dqdigidoc=$qdigidoc" "-dminidriver=$minidriver" `
+        "-dupdater=$updater" "-dqesteidutil=$qesteid" "-dqdigidoc=$qdigidoc" "-dteraVersion=$teraVersion" "-dminidriver=$minidriver" `
         "-dieplugin=$ieplugin" "-dchrome=$chrome" "-dfirefox=$firefox" "-dloader=$loader" "-dshellext=$shellext" 
     & $light "$wxs.wixobj" -nologo -ext WixBalExtension -out "$filename"
     if($sign) {

--- a/metainfo.wxs
+++ b/metainfo.wxs
@@ -30,6 +30,8 @@
         <RegistryValue Root='HKMU' Key='SOFTWARE\[Manufacturer]\Open-EID'
                        Name='QesteidutilInstall' Value='[QESTEIDUTILINSTALL]' Type='integer' />
         <RegistryValue Root='HKMU' Key='SOFTWARE\[Manufacturer]\Open-EID'
+                       Name='TeRaInstall' Value='[TERAINSTALL]' Type='integer' />
+        <RegistryValue Root='HKMU' Key='SOFTWARE\[Manufacturer]\Open-EID'
                        Name='AutoUpdate' Value='[AUTOUPDATE]' Type='integer' />
         <RegistryValue Root='HKMU' Key='SOFTWARE\[Manufacturer]\Open-EID'
                        Name='IconsDesktop' Value='[ICONSDESKTOP]' Type='integer' />


### PR DESCRIPTION
IB-4735: Add new product TeRa to eID installer as external component
(installed to dedicated folder, not into common OpenEID folder).
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>